### PR TITLE
Ignore test item with place 'Irgendwo'

### DIFF
--- a/JSON/JSONListModel.qml
+++ b/JSON/JSONListModel.qml
@@ -52,7 +52,9 @@ Item {
         var objectArray = parseJSONString(json, query);
         for ( var key in objectArray ) {
             var jo = objectArray[key];
-            jsonModel.append( jo );
+            if (jo.place != "Irgendwo") {
+                jsonModel.append( jo );
+            }
         }
     }
 


### PR DESCRIPTION
Danke für TankenApp, es ist sehr praktisch! Ich bin Grade dabei die Map-Darstellung zu erweitern, und gleichzeitig QML Debugging zu lernen, In meine Tests liefert der API immer einer test Tankstelle 'Rasant' mit. Da die lat,long hier von weiter außerhalb von Deutschland sind ist die Map-Darstellung verzehrt. Deswegen diesen kleinen Patch um Tankstellen mit 'place' gleich 'Irgendwo' aus zu filteren.
